### PR TITLE
Implementation to use private subnet

### DIFF
--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -607,6 +607,15 @@ def setup_node(
 
     ensure_java8(ssh_client)
 
+    print("[{h}] Configuring hostname...".format(h=host))
+    ssh_check_output(
+        client=ssh_client,
+        command="""
+            set -e
+            fullname=`hostname`.ec2.internal
+            echo "{h} $fullname $(hostname)" |sudo tee -a /etc/hosts
+        """.format(h=host))
+
     for service in services:
         service.install(
             ssh_client=ssh_client,

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -81,19 +81,36 @@ class EC2Cluster(FlintrockCluster):
 
     @property
     def master_ip(self):
-        return self.master_instance.public_ip_address
+        if self.subnet_is_private:
+            return self.master_instance.private_ip_address
+        else:
+            return self.master_instance.public_ip_address
 
     @property
     def master_host(self):
-        return self.master_instance.public_dns_name
+        if self.subnet_is_private:
+            return self.master_instance.private_dns_name
+        else:
+            return self.master_instance.public_dns_name
 
     @property
     def slave_ips(self):
-        return [i.public_ip_address for i in self.slave_instances]
+        if self.subnet_is_private:
+            return [i.private_ip_address for i in self.slave_instances]
+        else:
+            return [i.public_ip_address for i in self.slave_instances]
 
     @property
     def slave_hosts(self):
-        return [i.public_dns_name for i in self.slave_instances]
+        if self.subnet_is_private:
+            return [i.private_dns_name for i in self.slave_instances]
+        else:
+            return [i.public_dns_name for i in self.slave_instances]
+
+    @property
+    def subnet_is_private(self):
+        ec2 = boto3.resource(service_name='ec2', region_name=self.region)
+        return not ec2.Subnet(self.master_instance.subnet_id).map_public_ip_on_launch
 
     @property
     def num_masters(self):
@@ -452,13 +469,6 @@ def check_network_config(*, region_name: str, vpc_id: str, subnet_id: str):
             "Flintrock requires DNS hostnames to be enabled.\n"
             "See: https://github.com/nchammas/flintrock/issues/43"
             .format(v=vpc_id)
-        )
-    if not ec2.Subnet(subnet_id).map_public_ip_on_launch:
-        raise ConfigurationNotSupported(
-            "{s} does not auto-assign public IP addresses. "
-            "Flintrock requires public IP addresses.\n"
-            "See: https://github.com/nchammas/flintrock/issues/14"
-            .format(s=subnet_id)
         )
 
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -331,7 +331,7 @@ class EC2Cluster(FlintrockCluster):
             self.slave_instances += new_slave_instances
             self.wait_for_state('running')
 
-            new_slaves = {i.public_ip_address for i in self.slave_instances} - existing_slaves
+            new_slaves = {i.public_ip_address or i.private_ip_address for i in self.slave_instances} - existing_slaves
 
             super().add_slaves(
                 user=user,


### PR DESCRIPTION
Implementation to use private subnet. This allow you to launch a cluster in private subnet VPC from your sweet home using Chaordic VPC.

Related to: https://github.com/chaordic/datalake-ignition/issues/207